### PR TITLE
Replace phpDocumentator download url to use current stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4-cli
-RUN curl -L https://github.com/gpupo/phpDocumentor/releases/download/v3.0.0-idependent/phpDocumentor.phar -o /usr/local/bin/phpDocumentor
+RUN curl -L https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0/phpDocumentor.phar -o /usr/local/bin/phpDocumentor
 COPY "entrypoint.sh" "/entrypoint.sh"
 RUN chmod +x /entrypoint.sh && chmod a+x /usr/local/bin/phpDocumentor
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR replaces the phpDocumentator url in the docker image with the url of the current stable version of phpDocumentator from the offical repository.